### PR TITLE
feat(config): Add nested defaults block and dry-run mode

### DIFF
--- a/.cursor/rules/configuration.mdc
+++ b/.cursor/rules/configuration.mdc
@@ -19,6 +19,26 @@ globs: "*.yaml,config*.go"
 organization: "org-name"
 ```
 
+### Repository Defaults (Optional)
+
+Use the nested `defaults` block to set global defaults for repository features:
+
+```yaml
+defaults:
+  wiki: false                   # Disable wikis by default
+  issues: true                  # Enable issues by default
+  projects: false               # Disable projects by default
+  delete_branch_on_merge: true  # Auto-delete head branches after PR merge
+```
+
+**Backward Compatibility:** Old-style `default_wiki`, `default_issues`, and `default_projects` fields are still supported and automatically migrated to the nested `defaults` block at runtime.
+
+**How Defaults Work:**
+1. Set global defaults in the `defaults` block
+2. Individual repositories inherit these defaults unless explicitly overridden
+3. Use `nil` (omit field) at repository level to inherit the default
+4. Specify a value at repository level to override the default
+
 ### Default Topics/Labels
 ```yaml
 default_topics:
@@ -28,52 +48,101 @@ default_topics:
 default_labels:
   - name: "bug"
     color: "d73a4a"
+    emoji: "🐛"
     description: "Something isn't working"
 ```
 
 ### Team Permissions
 ```yaml
-teams:
+team:
   - name: "platform"
-    permission: "admin"  # admin | push | pull | triage | maintain
+    level: "admin"  # admin | push | pull | triage | maintain
 ```
 
 ### Repositories
 ```yaml
 repositories:
-  - name: "my-repo"
-    description: "Repository description"
-    private: true
-    wiki: false
-    issues: true
-    projects: false
-    topics:  # Reserved for future per-repo customization
-      - "custom-topic"
-    teams:
-      - name: "platform"
-        permission: "admin"
+  # Inherits all defaults
+  - name: "simple-repo"
+
+  # Override specific defaults
+  - name: "docs-repo"
+    wiki: true  # Override: enable wiki for this repo
+    # issues: inherits from defaults
+    # projects: inherits from defaults
+    delete_branch_on_merge: false  # Override: keep branches
+
+  # Override all defaults
+  - name: "special-repo"
+    wiki: true
+    issues: false
+    projects: true
+    delete_branch_on_merge: true
+    discussions_enabled: true
+    sponsorships_enabled: false
 ```
 
 ### Branch Protection
 ```yaml
-    branch_protections:
-      - pattern: "main"
-        required_reviews: 2
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
-        required_status_checks:
-          - "ci/test"
-          - "ci/lint"
-        enforce_admins: true
-        allow_force_pushes: false
-        allow_deletions: false
+branches:
+  # Pull request requirements
+  require_pull_request_reviews: true
+  require_approving_count: 2
+  require_code_owners: true
+
+  # Merge strategy controls
+  allow_merge_commit: false
+  allow_squash_merge: true
+  allow_rebase_merge: true
+
+  # Status checks
+  require_status_checks: true
+  status_checks:
+    - "ci/build"
+    - "ci/test"
+  require_up_to_date_branch: true
+
+  # Advanced protection
+  enforce_admins: true
+  restrict_pushes: true
+  push_allowlist:
+    - "admin-team"
+  require_conversation_resolution: true
+  require_linear_history: true
+  allow_force_pushes: false
+  allow_deletions: false
 ```
 
-### Merge Strategies
-```yaml
-    allow_merge_commit: true
-    allow_squash_merge: true
-    allow_rebase_merge: false
+## Configuration Structs
+
+### RepositoryDefaults
+```go
+type RepositoryDefaults struct {
+    Wiki                *bool `yaml:"wiki,omitempty"`
+    Issues              *bool `yaml:"issues,omitempty"`
+    Projects            *bool `yaml:"projects,omitempty"`
+    DeleteBranchOnMerge *bool `yaml:"delete_branch_on_merge,omitempty"`
+}
+```
+
+### PermissionsSettings
+```go
+type PermissionsSettings struct {
+    Organization      *string             `yaml:"organization"`
+    Defaults          *RepositoryDefaults `yaml:"defaults,omitempty"`
+    BranchPermissions BranchPermissions   `yaml:"branches"`
+    TeamPermissions   []*Permissions      `yaml:"team"`
+    Repositories      []*Repository       `yaml:"repositories"`
+    DefaultLabels     []RepoLabel         `yaml:"default_labels"`
+    DefaultTopics     []string            `yaml:"default_topics,omitempty"`
+
+    // Deprecated: Use Defaults.Wiki instead
+    DefaultWiki       *bool               `yaml:"default_wiki,omitempty"`
+    // Deprecated: Use Defaults.Issues instead
+    DefaultIssues     *bool               `yaml:"default_issues,omitempty"`
+    // Deprecated: Use Defaults.Projects instead
+    DefaultProjects   *bool               `yaml:"default_projects,omitempty"`
+}
 ```
 
 ## Configuration Orchestration
@@ -81,12 +150,31 @@ repositories:
 Configuration structures in [config.go](mdc:config.go) include orchestration functions:
 
 ```go
-// Orchestrate topic synchronization
-func SyncTopics(settings *PermissionsSettings, client *GitHubClient, additive bool) {
-    for _, repo := range settings.Repositories {
-        // Apply default_topics to each repository
-        client.SyncTopics(*settings.Organization, *repo.Name, settings.DefaultTopics, additive)
+// Migrate legacy default_* fields to nested defaults block
+func (s *PermissionsSettings) MigrateToNestedDefaults() {
+    if s.Defaults == nil && (s.DefaultWiki != nil || s.DefaultIssues != nil || s.DefaultProjects != nil) {
+        s.Defaults = &RepositoryDefaults{
+            Wiki:     s.DefaultWiki,
+            Issues:   s.DefaultIssues,
+            Projects: s.DefaultProjects,
+        }
+        log.Info().Msg("migrated legacy default_* fields to defaults block")
     }
+}
+
+// Apply defaults using coalescing
+func setRepositoryFeatures(repo *Repository, repoID githubv4.ID, settings *PermissionsSettings, client *GitHubClient) {
+    var wiki, issues, projects *bool
+    if settings.Defaults != nil {
+        wiki = coalesceBoolPtr(repo.Wiki, settings.Defaults.Wiki)
+        issues = coalesceBoolPtr(repo.Issues, settings.Defaults.Issues)
+        projects = coalesceBoolPtr(repo.Projects, settings.Defaults.Projects)
+    } else {
+        wiki = repo.Wiki
+        issues = repo.Issues
+        projects = repo.Projects
+    }
+    // Apply settings...
 }
 ```
 
@@ -96,11 +184,19 @@ func SyncTopics(settings *PermissionsSettings, client *GitHubClient, additive bo
 - **`DefaultTopics`** (PermissionsSettings): Used by `topics` command to apply topics across all repos
 - **`Repository.Topics`**: Reserved for future per-repository topic customization (not currently used)
 
+### Defaults Inheritance Pattern
+- **Global defaults** in `PermissionsSettings.Defaults` apply to all repositories
+- **Per-repository values** in `Repository` struct override global defaults
+- **Nil values** at repository level inherit from global defaults
+- **coalesceBoolPtr** function handles the inheritance logic
+
 ## Validation
 
 - Type safety via Go structs
-- Required field validation
+- Required field validation (organization, repository names)
 - Team permission level validation
+- Branch protection consistency checks
+- Schema version migration support
 - Future: `validate` command for pre-flight checks (task-28)
 
 ## Commands Using Configuration
@@ -117,11 +213,29 @@ ownershit import      # Import existing repository settings
 ## Import Operations
 
 ```bash
-ownershit import --org myorg --repo myrepo
+ownershit import org/repo --output config.yaml
 ```
 
 Implementation: [import.go](mdc:import.go)
-Supports: Team permissions, branch protection, repository settings
+Supports: Team permissions, branch protection, repository settings, delete_branch_on_merge
+
+## Utility Scripts
+
+### Backfill Repository Features
+
+[scripts/backfill-repo-features.py](mdc:scripts/backfill-repo-features.py) helps migrate existing configurations:
+
+```bash
+export GITHUB_TOKEN=your_token
+uv run scripts/backfill-repo-features.py repositories.yaml
+```
+
+Features:
+- Detects actual wiki/issues/projects/delete_branch_on_merge usage
+- Supports both old (`default_*`) and new (`defaults` block) formats
+- Adds explicit settings where they differ from defaults
+- Removes redundant settings that match defaults
+- Creates `.backup` file before changes
 
 ## Security Best Practices
 
@@ -135,3 +249,37 @@ Supports: Team permissions, branch protection, repository settings
 - **Test fixtures:** [testdata/testrepoconfig.yaml](mdc:testdata/testrepoconfig.yaml)
 - **Parsing tests:** [config_parsing_test.go](mdc:config_parsing_test.go)
 - **Permission tests:** [config_permissions_test.go](mdc:config_permissions_test.go)
+- **Defaults tests:** Test both old and new format, migration logic, inheritance
+
+## Migration Guide
+
+To migrate from old format to new format:
+
+**Before:**
+```yaml
+organization: my-org
+default_wiki: false
+default_issues: true
+default_projects: false
+
+repositories:
+  - name: repo1
+    wiki: false
+    issues: true
+    projects: false
+```
+
+**After:**
+```yaml
+organization: my-org
+defaults:
+  wiki: false
+  issues: true
+  projects: false
+  delete_branch_on_merge: true
+
+repositories:
+  - name: repo1  # Inherits all defaults, no explicit settings needed
+```
+
+The old format continues to work with automatic migration at runtime.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Dry-run mode displays all planned changes without making any API calls to GitHub
 
 ### Example Output
 
-```
+```text
 INFO DRY RUN MODE - No changes will be applied
 INFO DRY RUN: Analyzing configuration changes...
 INFO Would process repository repository=account_vending_machine

--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ organization: your-org-name
 
 # Global defaults for repository features (optional)
 # These apply to all repositories unless explicitly overridden
-default_wiki: false      # Disable wikis by default
-default_issues: true     # Enable issues by default
-default_projects: false  # Disable projects by default
+defaults:
+  wiki: false                   # Disable wikis by default
+  issues: true                  # Enable issues by default
+  projects: false               # Disable projects by default
+  delete_branch_on_merge: true  # Auto-delete head branches after PR merge
 
 # Team permissions for repositories
 team:
@@ -202,13 +204,16 @@ Configure global defaults for repository features. These defaults apply to all r
 
 #### Available Default Settings
 
-- `default_wiki` - Enable/disable wikis for all repositories
-- `default_issues` - Enable/disable issue tracking for all repositories
-- `default_projects` - Enable/disable GitHub projects for all repositories
+Within the `defaults` block, you can configure:
+
+- `wiki` - Enable/disable wikis for all repositories
+- `issues` - Enable/disable issue tracking for all repositories
+- `projects` - Enable/disable GitHub projects for all repositories
+- `delete_branch_on_merge` - Automatically delete head branches after pull request merge
 
 #### How It Works
 
-1. **Global Defaults**: Set default values at the top level of your configuration
+1. **Global Defaults**: Set default values in the `defaults` block of your configuration
 2. **Per-Repository Overrides**: Specify values at the repository level to override defaults
 3. **Inheritance**: If a repository doesn't specify a value, it inherits from the default
 4. **Nil Behavior**: If no default is set and no repository value is provided, no change is made
@@ -219,9 +224,11 @@ Configure global defaults for repository features. These defaults apply to all r
 organization: my-org
 
 # Set defaults - most repos don't need wikis or projects
-default_wiki: false
-default_issues: true
-default_projects: false
+defaults:
+  wiki: false
+  issues: true
+  projects: false
+  delete_branch_on_merge: true
 
 repositories:
   # Inherits all defaults (wiki: false, issues: true, projects: false)
@@ -267,11 +274,13 @@ repositories:
     projects: false
 ```
 
-**After** (using defaults):
+**After** (using nested defaults):
 ```yaml
-default_wiki: false
-default_issues: true
-default_projects: false
+defaults:
+  wiki: false
+  issues: true
+  projects: false
+  delete_branch_on_merge: true
 
 repositories:
   - name: repo1
@@ -279,7 +288,27 @@ repositories:
   - name: repo3
 ```
 
-This feature is fully backward compatible - existing configurations continue to work unchanged.
+#### Backward Compatibility
+
+This feature is fully backward compatible. Old-style `default_*` fields are automatically migrated to the new nested `defaults` block at runtime:
+
+**Old format** (still supported):
+```yaml
+default_wiki: false
+default_issues: true
+default_projects: false
+```
+
+**New format** (recommended):
+```yaml
+defaults:
+  wiki: false
+  issues: true
+  projects: false
+  delete_branch_on_merge: true
+```
+
+When using the old format, you'll see a migration message in the logs, but everything will continue to work seamlessly.
 
 ## Development
 
@@ -389,15 +418,17 @@ This script:
 
 ```
 repositories.yaml
-├── organization: string          # GitHub organization name
-├── default_wiki: bool            # Global default (optional)
-├── default_issues: bool          # Global default (optional)
-├── default_projects: bool        # Global default (optional)
-├── branches: BranchPermissions   # Branch protection rules
-├── team: []TeamPermission        # Team access levels
-├── repositories: []Repository    # Repository configurations
-├── default_labels: []Label       # Default labels for all repos
-└── default_topics: []string      # Default topics for all repos
+├── organization: string            # GitHub organization name
+├── defaults: RepositoryDefaults    # Global defaults (optional)
+│   ├── wiki: bool                  # Default wiki setting
+│   ├── issues: bool                # Default issues setting
+│   ├── projects: bool              # Default projects setting
+│   └── delete_branch_on_merge: bool # Default auto-delete branches
+├── branches: BranchPermissions     # Branch protection rules
+├── team: []TeamPermission          # Team access levels
+├── repositories: []Repository      # Repository configurations
+├── default_labels: []Label         # Default labels for all repos
+└── default_topics: []string        # Default topics for all repos
 ```
 
 ### Key Files

--- a/README.md
+++ b/README.md
@@ -56,6 +56,50 @@ task install
    ownershit sync
    ```
 
+## Dry-Run Mode
+
+Preview changes before applying them using the `--dry-run` flag:
+
+```bash
+# Preview all changes that would be made
+ownershit sync --config repositories.yaml --dry-run
+
+# With debug output for detailed analysis
+ownershit sync --config repositories.yaml --dry-run --debug
+```
+
+### What Dry-Run Shows
+
+Dry-run mode displays all planned changes without making any API calls to GitHub:
+
+- Team permissions that would be added to repositories
+- Repository features that would be changed (wiki, issues, projects)
+- Branch protection rules that would be applied
+- Branch merge strategies that would be updated
+- Delete-branch-on-merge settings that would be configured
+
+### Example Output
+
+```
+INFO DRY RUN MODE - No changes will be applied
+INFO DRY RUN: Analyzing configuration changes...
+INFO Would process repository repository=account_vending_machine
+INFO Would update branch merge strategies repository=account_vending_machine
+INFO Would apply enhanced branch protection rules branch=main repository=account_vending_machine
+INFO Would update repository features issues=false projects=false wiki=false repository=account_vending_machine
+INFO Would update delete_branch_on_merge setting delete_branch_on_merge=true repository=account_vending_machine
+...
+INFO DRY RUN: Complete. No changes were applied.
+```
+
+### Use Cases
+
+- **Safety**: Verify configuration changes before applying them to production repositories
+- **Learning**: Understand what the tool will do without making actual changes
+- **Debugging**: Identify configuration issues or unexpected behavior
+- **CI/CD**: Validate configurations in automated pipelines
+- **Documentation**: Generate reports of planned changes for team review
+
 ## Commands
 
 ### Core Commands
@@ -63,7 +107,7 @@ task install
 | Command       | Description                             | Example                                            |
 | ------------- | --------------------------------------- | -------------------------------------------------- |
 | `init`        | Create a stub configuration file          | `ownershit init`                                   |
-| `sync`        | Synchronize all repository settings     | `ownershit sync --config repositories.yaml`         |
+| `sync`        | Synchronize all repository settings     | `ownershit sync --config repositories.yaml`<br>`ownershit sync --dry-run` |
 | `branches`    | Update branch merge strategies          | `ownershit branches`                               |
 | `label`       | Sync default labels across repositories | `ownershit label`                                  |
 | `topics`      | Sync repository topics/tags             | `ownershit topics --additive=true`                 |

--- a/cmd/ownershit/main.go
+++ b/cmd/ownershit/main.go
@@ -74,7 +74,7 @@ func main() {
 			{
 				Name:      "sync",
 				Usage:     "Synchronize branch, repo, owner and other configs on repositories",
-				UsageText: "ownershit sync --config repositories.yaml",
+				UsageText: "ownershit sync --config repositories.yaml [--dry-run]",
 				Before:    configureClient,
 				Action:    syncCommand,
 				Flags: []cli.Flag{
@@ -82,6 +82,11 @@ func main() {
 						Name:  "config",
 						Value: "repositories.yaml",
 						Usage: "configuration of repository updates to perform",
+					},
+					&cli.BoolFlag{
+						Name:    "dry-run",
+						Aliases: []string{"n"},
+						Usage:   "preview changes without applying them",
 					},
 				},
 			},
@@ -281,8 +286,12 @@ func readConfig(c *cli.Context) error {
 
 // syncCommand synchronizes repository settings based on the configuration file.
 func syncCommand(c *cli.Context) error {
+	dryRun := c.Bool("dry-run")
+	if dryRun {
+		log.Info().Msg("DRY RUN MODE - No changes will be applied")
+	}
 	log.Info().Msg("mapping all permissions for repositories")
-	shit.MapPermissions(settings, githubClient)
+	shit.MapPermissions(settings, githubClient, dryRun)
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -658,9 +658,10 @@ func setRepositoryFeatures(repo *Repository, repoID githubv4.ID, settings *Permi
 		issues = coalesceBoolPtr(repo.Issues, settings.Defaults.Issues)
 		projects = coalesceBoolPtr(repo.Projects, settings.Defaults.Projects)
 	} else {
-		wiki = repo.Wiki
-		issues = repo.Issues
-		projects = repo.Projects
+		// Fallback to legacy default_* fields for backward compatibility
+		wiki = coalesceBoolPtr(repo.Wiki, settings.DefaultWiki)
+		issues = coalesceBoolPtr(repo.Issues, settings.DefaultIssues)
+		projects = coalesceBoolPtr(repo.Projects, settings.DefaultProjects)
 	}
 
 	if dryRun {

--- a/config_defaults_test.go
+++ b/config_defaults_test.go
@@ -157,7 +157,7 @@ func TestDefaultRepositoryFeatures(t *testing.T) {
 				Return(nil).
 				Times(1)
 
-			setRepositoryFeatures(repo, repoID, settings, client)
+			setRepositoryFeatures(repo, repoID, settings, client, false)
 
 			// Verify the logic by checking what would be passed to SetRepository
 			wiki := repo.Wiki
@@ -218,7 +218,7 @@ func TestDefaultsBackwardCompatibility(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	setRepositoryFeatures(repo, repoID, settings, client)
+	setRepositoryFeatures(repo, repoID, settings, client, false)
 
 	// Verify explicit values are preserved
 	wiki := repo.Wiki

--- a/config_defaults_test.go
+++ b/config_defaults_test.go
@@ -137,6 +137,9 @@ func TestDefaultRepositoryFeatures(t *testing.T) {
 				DefaultProjects: tt.defaultProjects,
 			}
 
+			// Migrate legacy defaults to match runtime behavior
+			settings.MigrateToNestedDefaults()
+
 			repo := &Repository{
 				Name:     stringPtr("test-repo"),
 				Wiki:     tt.repoWiki,
@@ -160,17 +163,18 @@ func TestDefaultRepositoryFeatures(t *testing.T) {
 			setRepositoryFeatures(repo, repoID, settings, client, false)
 
 			// Verify the logic by checking what would be passed to SetRepository
+			// Use the migrated Defaults block, not legacy fields
 			wiki := repo.Wiki
-			if wiki == nil {
-				wiki = settings.DefaultWiki
+			if wiki == nil && settings.Defaults != nil {
+				wiki = settings.Defaults.Wiki
 			}
 			issues := repo.Issues
-			if issues == nil {
-				issues = settings.DefaultIssues
+			if issues == nil && settings.Defaults != nil {
+				issues = settings.Defaults.Issues
 			}
 			projects := repo.Projects
-			if projects == nil {
-				projects = settings.DefaultProjects
+			if projects == nil && settings.Defaults != nil {
+				projects = settings.Defaults.Projects
 			}
 
 			if !equalBoolPtr(wiki, tt.expectedWiki) {

--- a/config_test.go
+++ b/config_test.go
@@ -208,7 +208,7 @@ func TestMapPermissions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			MapPermissions(tt.args.settings, tt.args.client)
+			MapPermissions(tt.args.settings, tt.args.client, false)
 		})
 	}
 }

--- a/example-repositories.yaml
+++ b/example-repositories.yaml
@@ -6,9 +6,11 @@ organization: my-awesome-org
 
 # Global defaults for repository features
 # These apply to all repositories unless explicitly overridden at the repository level
-default_wiki: false      # Disable wikis by default
-default_issues: true     # Enable issues by default
-default_projects: false  # Disable projects by default
+defaults:
+  wiki: false                   # Disable wikis by default
+  issues: true                  # Enable issues by default
+  projects: false               # Disable projects by default
+  delete_branch_on_merge: true  # Auto-delete head branches after PR merge
 
 # Branch protection rules applied to all repositories
 branches:


### PR DESCRIPTION
## Summary

This PR introduces two major features that improve configuration management and operational safety:

1. **Nested Defaults Block**: Refactors configuration to use a cleaner nested structure
2. **Dry-Run Mode**: Adds safe preview functionality for the sync command

## Feature 1: Nested Defaults Block

Refactors the configuration structure to use a nested `defaults` block instead of multiple top-level `default_*` fields, making it cleaner and more extensible for future default settings.

### Configuration Format

**Before (old format - still supported):**
```yaml
organization: my-org
default_wiki: false
default_issues: true
default_projects: false
```

**After (new format - recommended):**
```yaml
organization: my-org
defaults:
  wiki: false
  issues: true
  projects: false
  delete_branch_on_merge: true  # NEW feature
```

### Key Changes
- **Added `RepositoryDefaults` struct** with fields for wiki, issues, projects, and delete_branch_on_merge
- **Automatic Migration**: Added `MigrateToNestedDefaults()` method that transparently migrates old `default_*` fields to the new format at runtime
- **Updated Coalescing Logic**: Modified `setRepositoryFeatures()` and `setAdvancedRepoSettings()` to use nested defaults with proper inheritance
- **Fully Backward Compatible**: Old configurations continue to work seamlessly with automatic migration

## Feature 2: Dry-Run Mode

Adds a `--dry-run` flag to the `sync` command that displays all planned changes without making actual API calls to GitHub, allowing users to safely preview what would happen.

### Usage

```bash
# Preview all changes
ownershit sync --dry-run

# With debug output for detailed analysis
ownershit sync --dry-run --debug
```

### What Dry-Run Shows

- Team permissions that would be added to repositories
- Repository features that would be changed (wiki, issues, projects)
- Branch protection rules that would be applied
- Branch merge strategies that would be updated
- Delete-branch-on-merge settings that would be configured

### Example Output

```
INFO DRY RUN MODE - No changes will be applied
INFO DRY RUN: Analyzing configuration changes...
INFO Would process repository repository=account_vending_machine
INFO Would update branch merge strategies repository=account_vending_machine
INFO Would apply enhanced branch protection rules branch=main repository=account_vending_machine
INFO Would update repository features issues=false projects=false wiki=false repository=account_vending_machine
INFO Would update delete_branch_on_merge setting delete_branch_on_merge=true repository=account_vending_machine
...
INFO DRY RUN: Complete. No changes were applied.
```

### Key Changes
- Added `--dry-run` flag (alias `-n`) to sync command
- Updated `MapPermissions` and all helper functions with dry-run support
- Comprehensive logging of all planned changes
- No API calls made when dry-run is enabled
- Fully backward compatible

## Files Modified

### Core Implementation
- `cmd/ownershit/main.go` - Added dry-run flag and updated syncCommand
- `config.go` - Nested defaults struct, migration logic, and dry-run support
- `example-repositories.yaml` - Updated to use nested defaults block
- `scripts/backfill-repo-features.py` - Support both old and new formats

### Documentation
- `README.md` - Comprehensive documentation for both features
- `.cursor/rules/configuration.mdc` - Updated configuration rules

### Tests
- `config_test.go` - Updated for new function signatures
- `config_defaults_test.go` - Updated for new function signatures

## Testing

- ✅ All tests pass (65.7% coverage maintained)
- ✅ Code formatted with `go fmt` and `gofmt`
- ✅ Manually tested dry-run with full repositories.yaml
- ✅ Configuration validation works with both old and new formats
- ✅ Migration logic tested and working
- ✅ Fully backward compatible

## Benefits

### Nested Defaults Block
1. **Cleaner Configuration**: Nested structure is more organized and intuitive
2. **Extensibility**: Easy to add new default settings in the future
3. **New Feature**: Added `delete_branch_on_merge` to defaults
4. **Zero Breaking Changes**: Complete backward compatibility maintained

### Dry-Run Mode
1. **Safety**: Verify changes before applying to production repositories
2. **Confidence**: See exactly what will change
3. **Debugging**: Identify configuration issues before runtime
4. **Learning**: Understand tool behavior without side effects
5. **CI/CD**: Validate configurations in automated pipelines

## Backward Compatibility

✅ **Fully backward compatible** for both features:
- Old `default_*` fields automatically migrated at runtime with informative log message
- All existing configurations work without modification
- Dry-run is an optional flag that doesn't affect normal operation
- No breaking changes

## Related Issues

Addresses:
- Request to add a top-level default for `delete_branch_on_merge`
- Need for safe preview mode before applying changes
- Improved configuration structure for future maintainability

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally (65.7% coverage)
- [x] Documentation updated comprehensively
- [x] Backward compatibility maintained
- [x] No breaking changes introduced
- [x] Dry-run mode tested manually
- [x] Migration logic verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added dry-run mode for the sync command to preview changes without applying them.
  - Introduced a Repository Defaults block with inheritance for repo features, including delete-branch-on-merge.
  - Consolidated branch protection settings under a unified Branches configuration.

- Changes
  - Legacy default fields remain supported but are migrated into the new defaults structure at runtime.
  - Renamed team permission field from “permission” to “level”.
  - Default labels now include an emoji.

- Documentation
  - Added migration guide, updated diagrams/examples, and detailed dry-run usage.
  - Refreshed example configurations to demonstrate defaults inheritance and overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->